### PR TITLE
Jade version update in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		}
   , "dependencies" : {
     	  "express" : "2.5.1"
-			, "jade" : ">= 0.0.1"
+			, "jade" : "0.24.0"
     	, "socket.io" : "0.8.7"
     	, "mongoose" : "2.5.5"
     	, "everyauth" : "0.2.30"


### PR DESCRIPTION
Javascript in index.jade is not working with current jade version:

```
Express
500 Error: /home/user/WebstormProjects/Node-polls/views/index.jade:85 83| script(type="text/javascript") 84| $(function(){ > 85| $('.add-option').click(function(e){ 86| e.preventDefault(); 87| var opt_length = $('.poll_options input[type=text]').length + 1; 88| var option = $('.poll_options input[type=text]:last').parent().clone(); unexpected token "indent"

    at Parser.parseExpr (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/parser.js:252:15)
    at Parser.block (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/parser.js:708:25)
    at Parser.tag (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/parser.js:817:24)
    at Parser.parseTag (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/parser.js:738:17)
    at Parser.parseExpr (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/parser.js:211:21)
    at Parser.parse (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/parser.js:122:25)
    at parse (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/index.js:104:21)
    at Object.exports.compile (/home/user/WebstormProjects/Node-polls/node_modules/jade/lib/index.js:205:16)
    at Function.exports.compile (/home/user/WebstormProjects/Node-polls/node_modules/express/lib/view.js:65:33)
    at ServerResponse.res._render (/home/user/WebstormProjects/Node-polls/node_modules/express/lib/view.js:414:18)
```

this can be fixed by using an old jade version in packages.json, e,g, "jade" : <code>"0.24.0"</code>